### PR TITLE
let phpstan-executable be absolute path to phpstan

### DIFF
--- a/phpstan.el
+++ b/phpstan.el
@@ -218,6 +218,7 @@ it returns the value of `SOURCE' as it is."
 (defun phpstan-get-executable ()
   "Return PHPStan excutable file and arguments."
   (cond
+   ((file-exists-p phpstan-executable) (list phpstan-executable))
    ((eq 'docker phpstan-executable)
     (list "run" "--rm" "-v"
           (concat (expand-file-name (php-project-get-root-dir)) ":/app")


### PR DESCRIPTION
I'll let you see if this is a good way to handle this use case, but adding this line let me link phpstan-executable to the absolute path of phpstan.

Otherwise, it was ignored : https://github.com/emacs-php/phpstan.el/issues/6