### PR TITLE
Fixed problem for use vendor phpstan

### DIFF
--- a/phpstan.el
+++ b/phpstan.el
@@ -224,7 +224,8 @@ it returns the value of `SOURCE' as it is."
           "phpstan/phpstan"))
    ((and (consp phpstan-executable)
          (eq 'root (car phpstan-executable)))
-    (expand-file-name (cdr phpstan-executable) (php-project-get-root-dir)))
+    (list
+     (expand-file-name (cdr phpstan-executable) (php-project-get-root-dir))))
    ((and (stringp phpstan-executable) (file-exists-p phpstan-executable))
     (list phpstan-executable))
    ((and phpstan-flycheck-auto-set-executable


### PR DESCRIPTION
refs https://github.com/emacs-php/phpstan.el/issues/10

This is a simple mistake. This function requires a list of string, this pattern assigns just a string to the variable.  Since a character string is a type of sequence, the append function treats it as a vector of char(int) instead of type error.

This issue was reported by @kwvanderlinde, thanks!