### PR TITLE
Modify README about installation

### DIFF
--- a/README.org
+++ b/README.org
@@ -52,10 +52,9 @@ If your project Composer relies on phpstan, you do not need to set anything.
          (phpstan-level . 7))))
 #+END_SRC
 *** Using PHAR archive
-*NOTICE*: ~phpstan.el~ is incompatible with the [[https://github.com/phpstan/phpstan/releases][released versions]] of PHPStan.  It will probably be distributed in the form of the Phar archive when the current development version is officially released in the near future.
+*NOTICE*: ~phpstan.el~ requires PHPStan **0.10+**.
 
-If you want to use the Phar archive you built yourself, set the Phar archive path to phpstan-executable.
-
+Please download ~phpstan.phar~ from [[https://github.com/phpstan/phpstan/releases][Releases · phpstan/phpstan]].
 ** Settings
 Variables for phpstan are mainly controlled by [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html][directory variables]] (~.dir-locals.el~).
 

--- a/README.org
+++ b/README.org
@@ -52,6 +52,18 @@ If your project Composer relies on phpstan, you do not need to set anything.
          (phpstan-config-file . (root . "path/to/dir/phpstan-docker.neon"))
          (phpstan-level . 7))))
 #+END_SRC
+*** Using Composer
+Please install [[https://packagist.org/packages/phpstan/phpstan-shim][phpstan/phpstan-shim]] or [[https://packagist.org/packages/phpstan/phpstan][phpstan/phpstan]] package for each user environment or project by using [[https://getcomposer.org/download/][Composer]].
+
+If you are unfamiliar with resolving dependencies, the following shell commands are recommended.
+#+BEGIN_SRC shell
+$ composer global require phpstan/phpstan-shim
+#+END_SRC
+*Hint*: If you failed the installation due to old PsySH or php-parser, try the following shell command.
+#+BEGIN_SRC shell
+$ composer global remove psy/psysh nikic/php-parser
+$ composer global require phpstan/phpstan-shim psy/psysh
+#+END_SRC
 *** Using PHAR archive
 *NOTICE*: ~phpstan.el~ requires PHPStan **0.10+**.
 

--- a/README.org
+++ b/README.org
@@ -7,6 +7,7 @@ Emacs interface to [[https://github.com/phpstan/phpstan][PHPStan]], includes che
 ** Support version
 - Emacs 24+
 - PHPStan latest/dev-master (NOT support 0.9 seriese)
+- PHP 7.1+ or Docker runtime
 ** How to install
 *** Install from MELPA
  1. If you have not set up MELPA, see [[https://melpa.org/#/getting-started][Getting Started - MELPA]].


### PR DESCRIPTION
PHPStan 0.10 was released on 2018-06-24, but the installation method in README was not updated.