### PR TITLE
Change errorFormat to error-format

### DIFF
--- a/phpstan.el
+++ b/phpstan.el
@@ -244,7 +244,7 @@ it returns the value of `SOURCE' as it is."
 (defun phpstan-get-command-args ()
   "Return command line argument for PHPStan."
   (let ((executable (phpstan-get-executable))
-        (args (list "analyze" "--errorFormat=raw" "--no-progress" "--no-interaction"))
+        (args (list "analyze" "--error-format=raw" "--no-progress" "--no-interaction"))
         (path (phpstan-normalize-path (phpstan-get-config-file)))
         (level (phpstan-get-level)))
     (when path


### PR DESCRIPTION
The `errorFormat` option was deprecated by phpstan/phpstan#1338

Note: since a backwards compatibility check was added and not everyone using this package may have the latest phpstan installed this PR shouldn't be merged immediately.