### PR TITLE
Use --error-format=raw instead of --errorFormat=raw

### DIFF
--- a/phpstan.el
+++ b/phpstan.el
@@ -244,7 +244,7 @@ it returns the value of `SOURCE' as it is."
 (defun phpstan-get-command-args ()
   "Return command line argument for PHPStan."
   (let ((executable (phpstan-get-executable))
-        (args (list "analyze" "--errorFormat=raw" "--no-progress" "--no-interaction"))
+        (args (list "analyze" "--error-format=raw" "--no-progress" "--no-interaction"))
         (path (phpstan-normalize-path (phpstan-get-config-file)))
         (level (phpstan-get-level)))
     (when path


### PR DESCRIPTION
Suppresses the following message from phpstan v0.10.5:

> Note: Using the option --errorFormat is deprecated. Use --error-format instead.