### PR TITLE
Fix phpstan-get-config-file for directory-variable

### DIFF
--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -46,7 +46,7 @@
 
 (defun flycheck-phpstan--enabled-and-set-variable ()
   "Return path to phpstan configure file, and set buffer execute in side effect."
-  (let ((enabled (and (phpstan-get-working-dir) (phpstan-get-config-file))))
+  (let ((enabled (or (phpstan-get-working-dir) (phpstan-get-config-file))))
     (prog1 enabled
       (when (and phpstan-flycheck-auto-set-executable
                  (not (and (boundp 'flycheck-phpstan-executable)

--- a/phpstan.el
+++ b/phpstan.el
@@ -181,10 +181,12 @@ NIL
           (expand-file-name (cdr phpstan-config-file) (php-project-get-root-dir))
         phpstan-config-file)
     (let ((working-directory (phpstan-get-working-dir)))
-      (cl-loop for name in '("phpstan.neon" "phpstan.neon.dist")
-               for dir  = (locate-dominating-file working-directory name)
-               if dir
-               return (expand-file-name name dir)))))
+      (if working-directory
+          nil
+        (cl-loop for name in '("phpstan.neon" "phpstan.neon.dist")
+                 for dir  = (locate-dominating-file working-directory name)
+                 if dir
+                 return (expand-file-name name dir))))))
 
 (defun phpstan-normalize-path (source-original &optional source)
   "Return normalized source file path to pass by `SOURCE-ORIGINAL' OR `SOURCE'.


### PR DESCRIPTION
refs #18
fix #19

The reason `or` rather than `and` is to use a [directory variable](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html) to specify the location of `phpstan.neon`.  That is, this variable allows `phpstan.neon` to be placed outside of the parent directory.