### PR TITLE
Flymake: Fix project root function call

### DIFF
--- a/flymake-phpstan.el
+++ b/flymake-phpstan.el
@@ -94,7 +94,7 @@
     (let ((source (current-buffer)))
       (save-restriction
         (widen)
-        (setq flymake-phpstan--proc (flymake-phpstan-make-process (php-project-root) command-args report-fn source))
+        (setq flymake-phpstan--proc (flymake-phpstan-make-process (php-project-get-root-dir) command-args report-fn source))
         (process-send-region flymake-phpstan--proc (point-min) (point-max))
         (process-send-eof flymake-phpstan--proc)))))
 


### PR DESCRIPTION
It was trying to call a var as a function, this solves it.