### PR TITLE
Flymake: Fix second group is not always a digit

### DIFF
--- a/flymake-phpstan.el
+++ b/flymake-phpstan.el
@@ -69,7 +69,7 @@
                    while (search-forward-regexp
                           (eval-when-compile
                             (rx line-start (1+ (not (any ":"))) ":"
-                                (group-n 1 (one-or-more (not (any ":"))) ":"
+                                (group-n 1 (one-or-more (not (any ":")))) ":"
                                 (group-n 2 (one-or-more not-newline)) line-end))
                           nil t)
                    for msg = (match-string 2)

--- a/flymake-phpstan.el
+++ b/flymake-phpstan.el
@@ -69,7 +69,7 @@
                    while (search-forward-regexp
                           (eval-when-compile
                             (rx line-start (1+ (not (any ":"))) ":"
-                                (group-n 1 (one-or-more digit)) ":"
+                                (group-n 1 (one-or-more (not (any ":"))) ":"
                                 (group-n 2 (one-or-more not-newline)) line-end))
                           nil t)
                    for msg = (match-string 2)


### PR DESCRIPTION
Sometimes it is '?'

Ex:
`?:?:Ignored error pattern #^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$# was not matched in reported errors.`

Fixes
```
Debugger entered--Lisp error: (error "Format specifier doesn’t match argument type")
  format-message("PHPStan error (exit status: %d)" signal)
  apply(format-message "PHPStan error (exit status: %d)" signal)
  user-error("PHPStan error (exit status: %d)" signal)
  (let ((code val)) (user-error "PHPStan error (exit status: %d)" code))
  (if (eq val (quote exit)) (progn (unwind-protect (if (save-current-buffer (set-buffer source) (eq proc flymake-phpstan--proc)) (progn (save-current-buffer (set-buffer (process-buffer proc)) (goto-char (point-min)) (let* (... ... ... ... ...) (while ... ... ... ... ...) (funcall report-fn diags) nil)) (flymake--log-1 :warning (quote nil) "Canceling obsolete check %s" proc))) (kill-buffer (process-buffer proc)))) (let ((code val)) (user-error "PHPStan error (exit status: %d)" code)))
  (let* ((val (process-status proc))) (if (eq val (quote exit)) (progn (unwind-protect (if (save-current-buffer (set-buffer source) (eq proc flymake-phpstan--proc)) (progn (save-current-buffer (set-buffer ...) (goto-char ...) (let* ... ... ... nil)) (flymake--log-1 :warning (quote nil) "Canceling obsolete check %s" proc))) (kill-buffer (process-buffer proc)))) (let ((code val)) (user-error "PHPStan error (exit status: %d)" code))))
  (closure ((source . #<buffer mentorpro.php>) (report-fn . #f(compiled-function (&rest args) #<bytecode 0x15fa899>)) (command-args "/home/mentorpro/dev/web/public_html/wp-content/plugins/mentorpro/vendor/bin/phpstan" "analyze" "--error-format=raw" "--no-progress" "--no-interaction" "-c" "/home/mentorpro/dev/web/public_html/wp-content/plugins/mentorpro/phpstan.neon" "-l" "max") (root . "~/dev/web/public_html/wp-content/plugins/mentorpro/") t) (proc _event) (let* ((val (process-status proc))) (if (eq val (quote exit)) (progn (unwind-protect (if (save-current-buffer (set-buffer source) (eq proc flymake-phpstan--proc)) (progn (save-current-buffer ... ... ...) (flymake--log-1 :warning ... "Canceling obsolete check %s" proc))) (kill-buffer (process-buffer proc)))) (let ((code val)) (user-error "PHPStan error (exit status: %d)" code)))))(#<process flymake-phpstan> "killed\n")
```