### PR TITLE
Use original name instead of yet another temp file

### DIFF
--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -68,7 +68,7 @@
   "PHP static analyzer based on PHPStan."
   :command ("php" (eval (phpstan-get-command-args))
             (eval (phpstan-normalize-path
-                   'flycheck-source-original
+                   (flycheck-save-buffer-to-temp #'flycheck-temp-file-system)
                    (flycheck-save-buffer-to-temp #'flycheck-temp-file-system))))
   :working-directory (lambda (_) (phpstan-get-working-dir))
   :enabled (lambda () (flycheck-phpstan--enabled-and-set-variable))

--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -68,7 +68,7 @@
   "PHP static analyzer based on PHPStan."
   :command ("php" (eval (phpstan-get-command-args))
             (eval (phpstan-normalize-path
-                   (flycheck-save-buffer-to-temp #'flycheck-temp-file-inplace)
+                   flycheck-source-original
                    (flycheck-save-buffer-to-temp #'flycheck-temp-file-system))))
   :working-directory (lambda (_) (phpstan-get-working-dir))
   :enabled (lambda () (flycheck-phpstan--enabled-and-set-variable))

--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -68,7 +68,7 @@
   "PHP static analyzer based on PHPStan."
   :command ("php" (eval (phpstan-get-command-args))
             (eval (phpstan-normalize-path
-                   flycheck-source-original
+                   'flycheck-source-original
                    (flycheck-save-buffer-to-temp #'flycheck-temp-file-system))))
   :working-directory (lambda (_) (phpstan-get-working-dir))
   :enabled (lambda () (flycheck-phpstan--enabled-and-set-variable))


### PR DESCRIPTION
Use the original file name (since that is, according to the docstring, what `phpstan-normalize-path` wants) instead of creating yet another temporary file that will confuse interpreters etc.