### PR TITLE
Modify phpstan configurations for test

### DIFF
--- a/tests/phpstan-docker.neon
+++ b/tests/phpstan-docker.neon
@@ -1,2 +1,3 @@
 parameters:
-        bootstrap: %currentWorkingDirectory%/../app/tests/bootstrap.php
+        bootstrapFiles:
+                - %currentWorkingDirectory%/../app/tests/bootstrap.php

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,2 +1,3 @@
 parameters:
-        bootstrap: %rootDir%/../../../tests/bootstrap.php
+        bootstrapFiles:
+                - %rootDir%/../../../tests/bootstrap.php


### PR DESCRIPTION
## About

- `phpstan-analyze-this-file` is not working with `test.php`
- Maybe the `parameter.bootstrap` configuration is old style for currently PHPStan
    - The `composer` installed `phpstan/phpstan:1.10.49`
- We should use the `bootstrapFiles` instead of `bootstrap` I think



