### PR TITLE
Fix a target path for docker execution

### DIFF
--- a/phpstan.el
+++ b/phpstan.el
@@ -338,15 +338,17 @@ it returns the value of `SOURCE' as it is."
 (defun phpstan-analyze-this-file ()
   "Analyze current buffer-file using PHPStan."
   (interactive)
-  (let ((file (expand-file-name (or buffer-file-name
-                                    (read-file-name "Choose a PHP script: ")))))
+  (let ((file (phpstan-normalize-path
+               (expand-file-name (or buffer-file-name
+                                     (read-file-name "Choose a PHP script: "))))))
     (compile (mapconcat #'shell-quote-argument
                         (phpstan-get-command-args :include-executable t :args (list file)) " "))))
 
 ;;;###autoload
 (defun phpstan-analyze-file (file)
   "Analyze a PHP script FILE using PHPStan."
-  (interactive (list (expand-file-name (read-file-name "Choose a PHP script: "))))
+  (interactive (list (phpstan-normalize-path
+                      (expand-file-name (read-file-name "Choose a PHP script: ")))))
   (compile (mapconcat #'shell-quote-argument
                       (phpstan-get-command-args :include-executable t :args (list file)) " ")))
 


### PR DESCRIPTION
## About

- `phpstan-analyze-this-file` and `phpstan-analyze-file` are not working when using `docker` 

## Reproduction

- Open `test-docker.php` in this repository
- `M-x phpstan-analyze-this-file`

### Output of current codes

```
-*- mode: compilation; default-directory: "/tmp/phpstan.el/" -*-
Compilation started at Wed Dec 13 08:14:16

docker run --rm -v /tmp/phpstan.el/\:/app ghcr.io/phpstan/phpstan analyze --error-format\=raw --no-progress --no-interaction -c /app/tests/phpstan-docker.neon --memory-limit 4G -l 7 -- /tmp/phpstan.el/test-docker.php
Path /tmp/phpstan.el/test-docker.php does not exist

Compilation exited abnormally with code 1 at Wed Dec 13 08:14:17, duration 0.48 s
```

- `/tmp/phpstan.el/test-docker.php` is wrong path
    - `/app` is missing

### Output of fixed codes

```
-*- mode: compilation; default-directory: "/tmp/phpstan.el/" -*-
Compilation started at Wed Dec 13 08:15:27

docker run --rm -v /tmp/phpstan.el/\:/app ghcr.io/phpstan/phpstan analyze --error-format\=raw --no-progress --no-interaction -c /app/tests/phpstan-docker.neon --memory-limit 4G -l 7 -- /app/test-docker.php
/app/test-docker.php:4:Function f not found.
/app/test-docker.php:7:Constant Fooo not found.

Compilation exited abnormally with code 1 at Wed Dec 13 08:15:28, duration 1.05 s
```


