### PR TITLE
Add phpstan-insert-dumptype command

### DIFF
--- a/README.org
+++ b/README.org
@@ -88,6 +88,17 @@ Typically, you would set the following ~.dir-locals.el~.
 #+END_SRC
 
 If there is a ~phpstan.neon~ file in the root directory of the project, you do not need to set both ~phpstan-working-dir~ and ~phpstan-config-file~.
+** Commands
+This package provides convenient commands for using PHPStan from Emacs.
+*** Command ~phpstan-insert-dumptype~
+Add ~\PHPStan\dumpType(...);~ to your PHP code and analyze it to make PHPStan display the type of the expression.
+#+BEGIN_SRC
+(define-key php-mode-map (kbd "C-c ^") #'phpstan-insert-dumptype)
+#+END_SRC
+
+By default, if you press ~C-u~ before invoking the command, ~\PHPStan\dumpPhpDocType()~ will be inserted.
+
+This feature was added in *PHPStan 1.12.7* and will dump types compatible with the ~@param~ and ~@return~ PHPDoc tags.
 
 ** API
 Most variables defined in this package are buffer local.  If you want to set it for multiple projects, use [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Default-Value.html][setq-default]].

--- a/phpstan.el
+++ b/phpstan.el
@@ -145,6 +145,15 @@ have unexpected behaviors or performance implications."
   :safe #'booleanp
   :group 'phpstan)
 
+(defconst phpstan-template-dump-type "\\PHPStan\\dumpType();")
+(defconst phpstan-template-dump-phpdoc-type "\\PHPStan\\dumpPhpDocType();")
+
+(defcustom phpstan-intert-dump-type-templates (cons phpstan-template-dump-type
+                                             phpstan-template-dump-phpdoc-type)
+  "Default template of PHPStan dumpType insertion."
+  :type '(cons string string)
+  :group 'phpstan)
+
 (defvar-local phpstan--use-xdebug-option nil)
 
 ;;;###autoload
@@ -479,6 +488,25 @@ it returns the value of `SOURCE' as it is."
             (phpstan-use-xdebug-option (list "--xdebug")))
            options
            (and args (cons "--" args)))))
+
+;;;###autoload
+(defun phpstan-insert-dumptype (&optional expression prefix-num)
+  "Insert PHPStan\\dumpType() expression-statement by EXPRESSION and PREFIX-NUM."
+  (interactive
+   (list
+    (if (region-active-p)
+        (buffer-substring-no-properties (region-beginning) (region-end))
+      (or (thing-at-point 'symbol t) ""))
+    current-prefix-arg))
+  (let ((template (if current-prefix-arg
+                      (cdr phpstan-intert-dump-type-templates)
+                    (car phpstan-intert-dump-type-templates))))
+    (move-end-of-line 1)
+    (newline-and-indent)
+    (insert template)
+    (search-backward "(" (line-beginning-position) t)
+    (forward-char)
+    (insert expression)))
 
 (provide 'phpstan)
 ;;; phpstan.el ends here


### PR DESCRIPTION
This is a command to insert a function to display PHPStan types into the buffer.

https://github.com/user-attachments/assets/10613acd-d891-4e62-8986-a0038ee0d3ff

It is recommended to set it to a key that is easy to press, as shown below.

```el
;; It can be typed in one stroke, but requires GUI Emacs.
(define-key php-mode-map (kbd "C-^") #'phpstan-insert-dumptype)

;;It can be typed in two strokes, but it works in the terminal.
(define-key php-mode-map (kbd "C-c ^") #'phpstan-insert-dumptype)
```

https://github.com/user-attachments/assets/0cdc7a34-0070-4e22-81f9-721287be74d0

If you put `C-u` before the key, `\PHPStan\dumpPhpDocType()` will be inserted.