### PR TITLE
Bump version 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,26 @@
 
 All notable changes of the `phpstan.el` are documented in this file using the [Keep a Changelog](https://keepachangelog.com/) principles.
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [0.9.0]
 
 ### Added
 
-* Add `phpstan-copy-dumped-type` command to copy the nearest dumped type from `PHPStan\dumpType()` or `PHPStan\dumpPhpDocType()` messages.
+* Add `phpstan-copy-dumped-type` command to copy the nearest dumped type from `PHPStan\dumpType()` or `PHPStan\dumpPhpDocType()` messages
+* Add support for PHPStan [Editor Mode](https://phpstan.org/user-guide/editor-mode)
+
+### Changed
+
+* Improved error handling when no JSON response is returned
+
+### Fixed
+
+* Fixed erroneous dependency from `flymake-phpstan` to Flycheck functions
+
+### Removed
+
+* Drop support for Emacs 25.3
 
 ## [0.8.2]
 

--- a/Eask
+++ b/Eask
@@ -1,7 +1,7 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
 (package "phpstan"
-         "0.8.2"
+         "0.9.0"
          "Interface to PHPStan (PHP static analyzer)")
 
 (website-url "https://github.com/emacs-php/phpstan.el")

--- a/README.org
+++ b/README.org
@@ -162,6 +162,13 @@ Use phpstan memory limit option when non-NIL.
      - ex) ~"1G"~
 - ~nil~ :: Use memory limit in php.ini
 
+*** Custom variable ~phpstan-activate-editor-mode~
+Determines whether PHPStan Editor Mode is available.
+
+- ~nil~ (default) :: Dynamically checks the PHPStan version by getting the path of the installed PHPStan executable.
+- ~'enabled~ :: Always use Editor Mode (this will cause an error in older versions of PHPStan)
+- ~'disabled~ :: Never use Editor Mode (no support for editors provided)
+
 *** Custom variable ~phpstan-docker-image~
 Docker image URL or Docker Hub image name or NIL.  Default as ~"ghcr.io/phpstan/phpstan"~.  See [[https://phpstan.org/user-guide/docker][Docker - PHPStan Documentation]]
  and [[https://github.com/orgs/phpstan/packages/container/package/phpstan][GitHub Container Registory - Package phpstan]].

--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -4,7 +4,7 @@
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 15 Mar 2018
-;; Version: 0.8.2
+;; Version: 0.9.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
 ;; Package-Requires: ((emacs "25.1") (flycheck "26") (phpstan "0.8.2"))

--- a/flymake-phpstan.el
+++ b/flymake-phpstan.el
@@ -4,7 +4,7 @@
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 31 Mar 2020
-;; Version: 0.8.2
+;; Version: 0.9.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
 ;; Package-Requires: ((emacs "26.1") (phpstan "0.8.2"))

--- a/phpstan.el
+++ b/phpstan.el
@@ -4,7 +4,7 @@
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 15 Mar 2018
-;; Version: 0.8.2
+;; Version: 0.9.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
 ;; Package-Requires: ((emacs "25.1") (compat "30") (php-mode "1.22.3") (php-runtime "0.2"))


### PR DESCRIPTION
### Added

* Add `phpstan-copy-dumped-type` command to copy the nearest dumped type from `PHPStan\dumpType()` or `PHPStan\dumpPhpDocType()` messages
* Add support for PHPStan [Editor Mode](https://phpstan.org/user-guide/editor-mode)

### Changed

* Improved error handling when no JSON response is returned

### Fixed

* Fixed erroneous dependency from `flymake-phpstan` to Flycheck functions

### Removed

* Drop support for Emacs 25.3
