### PR TITLE
Make Docker and Apple container actually work with flycheck-phpstan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ All notable changes of the `phpstan.el` are documented in this file using the [K
 * Fix `phpstan-executable` in the `(STRING . (ARGUMENTS ...))` form dropping the command name, which made the first *argument* run as the program (`("docker" "run" ...)` executed `run`).
 * Fix `phpstan-get-command-args` destructively modifying its inputs with `nconc`.  Each call appended the PHPStan arguments onto the caller's own list, growing `phpstan-executable` in the `(STRING . (ARGUMENTS ...))` form on every check, and appending `"--"` to `phpstan-generate-baseline-options` on every `phpstan-generate-baseline`.
 * Fix Flycheck getting stuck on a syntax check when PHPStan reported no files to analyse in a modified buffer.  The check now finishes with an empty result instead of never reporting a status.
+* Fix the analyzed file being passed to a containerized PHPStan as a host path.  `flycheck-phpstan` reported no errors at all with `(phpstan-executable . docker)`, because PHPStan answered `Path /Users/... does not exist`.  `flymake-phpstan` was affected for unmodified buffers.
+* Fix the `--tmp-file` copy being created in the system temporary directory when running containerized, where the container cannot see it.
+* Fix the JSON report being ignored when the container runtime prefixes it with progress output on STDERR, which made every check with `(phpstan-executable . container)` report no errors.
+* Fix `flycheck-phpstan` silently discarding the fallback warning when PHPStan produced no JSON report, hiding failures such as a broken configuration file behind a clean buffer.
 
 ## [0.9.0]
 

--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -69,23 +69,26 @@
 ;; Parsing PHPStan output:
 (defun flycheck-phpstan-parse-output (output &optional _checker _buffer)
   "Parse PHPStan errors from OUTPUT."
-  (let* ((json-buffer (with-current-buffer (flycheck-phpstan--temp-buffer)
-                        (erase-buffer)
-                        (insert output)
-                        (current-buffer)))
-         ;; Match `phpstan--parse-json', which skips everything before the
-         ;; first line starting with `{' so that output written to STDERR is
-         ;; ignored.  Anchoring at the start of OUTPUT instead would miss the
-         ;; JSON whenever the runtime prefixes it, as Apple container does
-         ;; with its progress report.
-         (data (if (string-match-p "^{" output)
-                   (phpstan--parse-json json-buffer)
-                 (list (flycheck-error-new-at 1 1 'warning (string-trim output)))))
-         (errors (phpstan--plist-to-alist (plist-get data :files))))
-    (unless phpstan-disable-buffer-errors
-      (phpstan-update-ignorebale-errors-from-json-buffer errors))
-    (phpstan-update-dumped-types errors)
-    (flycheck-phpstan--build-errors errors)))
+  ;; Look for a line starting with `{', the same condition
+  ;; `phpstan--parse-json' acts on: it skips everything before that line so
+  ;; that output written to STDERR is ignored, since the checker process
+  ;; merges STDERR into STDOUT.  Anchoring at the start of OUTPUT instead
+  ;; would miss the JSON whenever the runtime prefixes it, as Apple container
+  ;; does with its progress report.
+  (if (not (string-match-p "^{" output))
+      ;; PHPStan produced no report at all, so OUTPUT is a failure of some
+      ;; kind.  Surface it rather than reporting a clean buffer.
+      (list (flycheck-error-new-at 1 1 'warning (string-trim output)))
+    (let* ((json-buffer (with-current-buffer (flycheck-phpstan--temp-buffer)
+                          (erase-buffer)
+                          (insert output)
+                          (current-buffer)))
+           (data (phpstan--parse-json json-buffer))
+           (errors (phpstan--plist-to-alist (plist-get data :files))))
+      (unless phpstan-disable-buffer-errors
+        (phpstan-update-ignorebale-errors-from-json-buffer errors))
+      (phpstan-update-dumped-types errors)
+      (flycheck-phpstan--build-errors errors))))
 
 (defun flycheck-phpstan--temp-buffer ()
   "Return a temporary buffer for decode JSON."

--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -73,7 +73,12 @@
                         (erase-buffer)
                         (insert output)
                         (current-buffer)))
-         (data (if (string-prefix-p "{" output)
+         ;; Match `phpstan--parse-json', which skips everything before the
+         ;; first line starting with `{' so that output written to STDERR is
+         ;; ignored.  Anchoring at the start of OUTPUT instead would miss the
+         ;; JSON whenever the runtime prefixes it, as Apple container does
+         ;; with its progress report.
+         (data (if (string-match-p "^{" output)
                    (phpstan--parse-json json-buffer)
                  (list (flycheck-error-new-at 1 1 'warning (string-trim output)))))
          (errors (phpstan--plist-to-alist (plist-get data :files))))

--- a/flymake-phpstan.el
+++ b/flymake-phpstan.el
@@ -95,8 +95,9 @@
 
 (defun flymake-phpstan--create-temp-file ()
   "Create temp file and return the path."
-  (phpstan-normalize-path
-   (flymake-proc-init-create-temp-buffer-copy 'flymake-proc-create-temp-inplace)))
+  ;; `phpstan-get-command-args' translates the path for the container mount
+  ;; point, so return the path as it is on this side.
+  (flymake-proc-init-create-temp-buffer-copy 'flymake-proc-create-temp-inplace))
 
 (defun flymake-phpstan (report-fn &rest _ignored-args)
   "Flymake backend for PHPStan report using REPORT-FN."

--- a/phpstan.el
+++ b/phpstan.el
@@ -568,15 +568,27 @@ it returns the value of `SOURCE' as it is."
              (phpstan-use-xdebug-option (list "--xdebug")))
             options
             (when editor
-              (let ((original-file (plist-get editor :original-file)))
+              (let* ((original-file (plist-get editor :original-file))
+                     ;; PHPStan may see the project through a mount point, so
+                     ;; every path handed to it has to be translated, exactly
+                     ;; like the config file above.
+                     (target-file (phpstan-normalize-path original-file)))
                 (cond
                  ((funcall (plist-get editor :analyze-original) original-file)
-                  (list "--" original-file))
+                  (list "--" target-file))
                  ((phpstan-editor-mode-available-p (car (phpstan-get-executable-and-args)))
-                  (list "--tmp-file" (funcall (plist-get editor :temp-file))
-                        "--instead-of" original-file
-                        "--" original-file))
-                 ((list "--" (funcall (plist-get editor :inplace)))))))
+                  ;; A container only sees the project, so the temporary copy
+                  ;; has to be created inside it.  `:temp-file' puts it in the
+                  ;; system temporary directory, which is not mounted.
+                  (let ((temp-file (funcall (plist-get editor
+                                                       (if (phpstan--container-executable-p)
+                                                           :inplace
+                                                         :temp-file)))))
+                    (list "--tmp-file" (phpstan-normalize-path temp-file)
+                          "--instead-of" target-file
+                          "--" target-file)))
+                 ((list "--" (phpstan-normalize-path
+                              (funcall (plist-get editor :inplace))))))))
             (if editor args (cons "--" args)))))
 
 (defun phpstan-update-ignorebale-errors-from-json-buffer (errors)


### PR DESCRIPTION
Makes Docker and Apple container actually work with `flycheck-phpstan`. Both were broken before #62 as well — #62 wired the runtimes up correctly, but three separate defects downstream meant a containerized check still reported nothing.

**Stacked on #62.** Please merge that first; this branch targets it.

## The three defects

**1. The analyzed file was passed as a host path.** `phpstan-get-command-args` translated the config file with `phpstan-normalize-path` but not the target, so PHPStan answered `Path /Users/.../test-docker.php does not exist` and reported no errors. `flymake-phpstan` dodged this for modified buffers by normalizing the temp file itself, but was affected for unmodified ones.

Normalization now happens in `phpstan-get-command-args`, the one place that already knows about the mount point, and the redundant call in `flymake-phpstan--create-temp-file` is dropped so there is a single source of truth.

The `--tmp-file` branch needed more than translation: `:temp-file` creates the copy in the system temporary directory, which is not mounted and therefore invisible to the container. It now uses the in-place copy when containerized. That branch is only reachable for containers with `phpstan-activate-editor-mode` set to `enabled`, since version detection currently disables editor mode for them, but it was wrong either way.

**2. The JSON report was ignored when prefixed.** `phpstan--parse-json` deliberately skips everything before the first line starting with `{`, because the checker process merges STDERR into STDOUT. Its caller disagreed and only took the JSON branch when the *whole* output started with `{`. Docker stays quiet once the image is local, so this went unnoticed — but Apple container reports progress on STDERR for every run:

```
[0/6] [0s]
[1/6] Fetching image [0s]
...
```

so the JSON was never parsed and every check came back clean.

**3. Failures were discarded.** When there was no JSON at all, the fallback built a warning holding the raw output and then threw it away — `data` is a list of `flycheck-error`, so `(plist-get data :files)` returned nil. Every failure that stopped PHPStan from producing a report (broken config, bad `-c` path, a crash) was shown as a buffer with no errors. This is why the two defects above were silent rather than loud.

## Verification

Ran Flycheck for real against `ghcr.io/phpstan/phpstan` on both runtimes:

| case | before | after |
|---|---|---|
| docker, unmodified buffer | 0 errors | 2 errors ✅ |
| container, unmodified buffer | 0 errors | 2 errors ✅ |
| container, modified buffer (in-place copy) | 0 errors | 3 errors ✅ |
| container, modified, `phpstan-activate-editor-mode` = `enabled` (`--tmp-file`) | 0 errors | 3 errors ✅ |
| `("docker" "run" ...)` explicit form | 0 errors | 2 errors ✅ |

All match what local `vendor/bin/phpstan` reports for the same fixture, with no leftover temporary files. Local (non-container) execution is unchanged. With a config file PHPStan cannot use, the checker now reports `Bootstrap file /.../tests/bootstrap.php does not exist.` instead of nothing.

## Still open

`phpstan-editor-mode-available-p` runs `docker --version` and parses `d1c06ef` out of `Docker version 29.5.3, build d1c06ef` as the PHPStan version, so editor mode stays silently disabled for container users — they get the in-place copy branch, which works. Fixing it needs a design decision (running `IMAGE --version` costs a container start per check, and the `phpstan-executable-versions-alist` cache is keyed by executable string), so it is left for a follow-up.
