### PR TITLE
Require Emacs 27.1, pin dependencies to MELPA Stable

### DIFF
--- a/.github/run-emacs-27-2.sh
+++ b/.github/run-emacs-27-2.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build this package with Emacs 27.2 from nix-emacs-ci.
+#
+# CI does not cover Emacs 27 (see .github/workflows/test.yml), so this is the
+# way to check the floor declared in Package-Requires by hand.
+#
+# nix-emacs-ci does not expose Emacs 27 on aarch64-darwin, only on
+# x86_64-darwin, so on Apple Silicon this runs through Rosetta.  That needs
+# `extra-platforms = x86_64-darwin` in /etc/nix/nix.conf.  Reaching the
+# prebuilt binaries also needs your user in `trusted-users` there, otherwise
+# the daemon silently ignores the substituter below and builds from source.
+set -euo pipefail
+
+# Pinned rather than master, so that the Emacs you get today is the Emacs you
+# got last time.  nix-emacs-ci pins nixpkgs in its own flake.lock, so following
+# master would change the derivation -- and on a platform without prebuilt
+# binaries (see below) that means rebuilding Emacs from source.
+NIX_EMACS_CI_REV=${NIX_EMACS_CI_REV:-ca88f42462347e8e17859645aa59b156617e98fb}
+NIX_EMACS_CI=${NIX_EMACS_CI:-https://github.com/purcell/nix-emacs-ci/archive/${NIX_EMACS_CI_REV}.tar.gz}
+EMACS_ATTR=${EMACS_ATTR:-emacs-27-2}
+
+case "$(uname -s)/$(uname -m)" in
+  Darwin/arm64) SYSTEM=x86_64-darwin ;;
+  Darwin/*)     SYSTEM=x86_64-darwin ;;
+  Linux/x86_64) SYSTEM=x86_64-linux ;;
+  Linux/aarch64) SYSTEM=aarch64-linux ;;
+  *) echo "unsupported host: $(uname -s)/$(uname -m)" >&2; exit 1 ;;
+esac
+
+cd "$(dirname "$0")/.."
+
+echo "==> Fetching ${EMACS_ATTR} for ${SYSTEM}"
+emacs_path=$(nix-build --no-out-link \
+  --option system "${SYSTEM}" \
+  --option extra-substituters https://emacs-ci.cachix.org \
+  --option extra-trusted-public-keys emacs-ci.cachix.org-1:B5FVOrxhXXrOL0S+tQ7USrhjMT5iOPH+QN9q0NItom4= \
+  -A "${EMACS_ATTR}" \
+  -E "import (fetchTarball \"${NIX_EMACS_CI}\")")
+
+export PATH="${emacs_path}/bin:${PATH}"
+export EMACS="${emacs_path}/bin/emacs"
+
+echo "==> $("${EMACS}" --version | head -1)"
+
+# Stale .elc files silently win over newer .el, which would hide a failure.
+find . -maxdepth 1 -name '*.elc' -delete
+rm -rf .eask
+
+echo "==> eask install-deps"
+eask install-deps
+
+echo "==> eask compile"
+eask compile
+
+echo "==> OK"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,12 @@ jobs:
           - 30.1
         experimental: [false]
         include:
+        # Emacs 27.1 is the declared floor.  Run it on Ubuntu only: its
+        # dependencies come from MELPA Stable via Eask.27 (MELPA's HEAD needs
+        # Emacs 28.1), and one platform is enough to catch a 27-specific break.
+        - os: ubuntu-latest
+          emacs-version: "27.2"
+          experimental: false
         - os: ubuntu-latest
           emacs-version: snapshot
           experimental: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes of the `phpstan.el` are documented in this file using the [K
 * Fix editor mode detection asking the wrong program for its version.  Only the first element of the command line was probed, which is the container runtime for `(phpstan-executable . docker)` / `container` and `php` for a PHAR without the executable bit — so `docker --version` and `php --version` were parsed as PHPStan versions (`d1c06ef`, `Technologies`) and editor mode was silently disabled for every setup except a directly executable `phpstan`.
 * `phpstan-version` and `phpstan-editor-mode-available-p` now take the whole command line, as returned by `phpstan-get-executable-and-args`.  A bare string is still accepted.  `phpstan-version` no longer merges STDERR into the version string, which a container runtime pollutes with its progress report.
 
+### Removed
+
+* Drop support for Emacs 26 and earlier.  All files now require Emacs 27.1, which is also the floor of `php-mode` and `flycheck` themselves, so anything older could not have resolved its dependencies anyway.
+
 ## [0.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes of the `phpstan.el` are documented in this file using the [K
 * Fix `flycheck-phpstan` silently discarding the fallback warning when PHPStan produced no JSON report, hiding failures such as a broken configuration file behind a clean buffer.
 * Fix editor mode detection asking the wrong program for its version.  Only the first element of the command line was probed, which is the container runtime for `(phpstan-executable . docker)` / `container` and `php` for a PHAR without the executable bit — so `docker --version` and `php --version` were parsed as PHPStan versions (`d1c06ef`, `Technologies`) and editor mode was silently disabled for every setup except a directly executable `phpstan`.
 * `phpstan-version` and `phpstan-editor-mode-available-p` now take the whole command line, as returned by `phpstan-get-executable-and-args`.  A bare string is still accepted.  `phpstan-version` no longer merges STDERR into the version string, which a container runtime pollutes with its progress report.
+* Fix `declare-function` forms for `tramp` that quoted the function name and argument list (and misspelled `tramp` as `tamp`), so the byte compiler warned that `tramp-dissect-file-name` might not be defined at runtime.
 
 ### Removed
 

--- a/Eask
+++ b/Eask
@@ -15,7 +15,7 @@
 (source 'gnu)
 (source 'melpa)
 
-(depends-on "emacs" "24.3")
+(depends-on "emacs" "27.1")
 (depends-on "compat")
 (depends-on "php-mode")
 (depends-on "php-runtime")

--- a/Eask.27
+++ b/Eask.27
@@ -1,0 +1,35 @@
+;; -*- mode: eask; lexical-binding: t -*-
+
+;; Emacs 27-only variant of `Eask'.  Eask reads `Eask.27' in preference to
+;; `Eask' on Emacs 27, so this redirects only that version to MELPA Stable.
+;;
+;; MELPA's php-mode and flycheck track Emacs master: flycheck HEAD requires
+;; Emacs 28.1 and will not install on 27.  MELPA Stable's releases still
+;; support 27 (flycheck 36.0, php-mode 1.27.0), so the 27 CI job and the local
+;; .github/run-emacs-27-2.sh check both use them.
+;;
+;; This is a copy of `Eask' with one line changed -- the `source'.  Keep the
+;; rest in sync with `Eask', which is the source of truth.
+
+(package "phpstan"
+         "0.9.0"
+         "Interface to PHPStan (PHP static analyzer)")
+
+(website-url "https://github.com/emacs-php/phpstan.el")
+(keywords "tools" "php")
+
+(package-file "phpstan.el")
+(files "*.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source 'gnu)
+(source 'melpa-stable)
+
+(depends-on "emacs" "27.1")
+(depends-on "compat")
+(depends-on "php-mode")
+(depends-on "php-runtime")
+(depends-on "flycheck")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/README.org
+++ b/README.org
@@ -5,7 +5,7 @@
 #+END_HTML
 Emacs interface to [[https://github.com/phpstan/phpstan][PHPStan]], includes checker for [[http://www.flycheck.org/en/latest/][Flycheck]].
 ** Support version
-- Emacs 26+
+- Emacs 27.1+
 - PHPStan latest/dev-master (NOT support 0.9 seriese)
 - PHP 7.1+ or Docker runtime
 

--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -7,7 +7,7 @@
 ;; Version: 0.9.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
-;; Package-Requires: ((emacs "25.1") (flycheck "26") (phpstan "0.9.0"))
+;; Package-Requires: ((emacs "27.1") (flycheck "26") (phpstan "0.9.0"))
 ;; License: GPL-3.0-or-later
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/flymake-phpstan.el
+++ b/flymake-phpstan.el
@@ -7,7 +7,7 @@
 ;; Version: 0.9.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
-;; Package-Requires: ((emacs "26.1") (phpstan "0.9.0"))
+;; Package-Requires: ((emacs "27.1") (phpstan "0.9.0"))
 ;; License: GPL-3.0-or-later
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/phpstan-hover.el
+++ b/phpstan-hover.el
@@ -6,7 +6,7 @@
 ;; Created: 16 Feb 2026
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
-;; Package-Requires: ((emacs "26.1") (phpstan "0.9.0"))
+;; Package-Requires: ((emacs "27.1") (phpstan "0.9.0"))
 ;; License: GPL-3.0-or-later
 
 ;;; Commentary:

--- a/phpstan.el
+++ b/phpstan.el
@@ -7,7 +7,7 @@
 ;; Version: 0.9.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
-;; Package-Requires: ((emacs "25.1") (compat "30") (php-mode "1.22.3") (php-runtime "0.2"))
+;; Package-Requires: ((emacs "27.1") (compat "30") (php-mode "1.22.3") (php-runtime "0.2"))
 ;; License: GPL-3.0-or-later
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/phpstan.el
+++ b/phpstan.el
@@ -63,8 +63,8 @@
   (require 'php)
   (require 'json)
   (require 'tramp)
-  (declare-function 'tramp-dissect-file-name "tramp" '(name &optional nodefault))
-  (declare-function 'tramp-file-name-localname "tamp" '(cl-x)))
+  (declare-function tramp-dissect-file-name "tramp" (name &optional nodefault))
+  (declare-function tramp-file-name-localname "tramp" (cl-x)))
 
 ;; Variables:
 (defgroup phpstan nil


### PR DESCRIPTION
Aligns the declared Emacs floor with reality, pins dependencies to MELPA Stable, and verifies the result on a real Emacs 27.2.

## Require Emacs 27.1 everywhere

The declared floor was inconsistent and wrong: 25.1 in `phpstan.el` and `flycheck-phpstan.el`, 26.1 in `flymake-phpstan.el` and `phpstan-hover.el`, "Emacs 26+" in the README, 24.3 in `Eask`. But `php-mode` (1.27.0) and `flycheck` (36.0) each require `(emacs (27 1))` themselves, so a 26.x user could never have resolved the dependencies. CI already dropped 27.2 because it does not pass. Everything now says 27.1.

## Pin dependencies to MELPA Stable

`(source 'melpa)` pulled whatever was on MELPA that day — builds were resolving `php-mode 20260716.1807` and `flycheck 20260717.456`, so a CI failure could come from a dependency's unreleased HEAD rather than from this package, and two runs a day apart were not testing the same thing. MELPA Stable carries releases new enough for our requirements (php-mode 1.27.0 ≥ 1.22.3, php-runtime 0.3.2 ≥ 0.2, flycheck 36.0 ≥ 26); compat comes from GNU ELPA regardless.

## Verified on Emacs 27.2

Added `.github/run-emacs-27-2.sh`, which fetches Emacs 27.2 from [nix-emacs-ci](https://github.com/purcell/nix-emacs-ci) and runs `eask install-deps` + `eask compile`. Ran it: **clean compile, 4/4 files, no warnings**, with the MELPA Stable dependencies.

A couple of notes worth recording for whoever runs this next, on Apple Silicon:

- nix-emacs-ci does **not** expose Emacs 27 on `aarch64-darwin` (its flake excludes it — old Emacs fails to build there), only on `x86_64-darwin`. So this runs through Rosetta, which needs `extra-platforms = x86_64-darwin` in `/etc/nix/nix.conf`.
- The prebuilt binaries are **not cached** for `x86_64-darwin` (nix-emacs-ci's own CI does not build that platform), so the first run compiles Emacs from source (~30 min). The script pins the nix-emacs-ci revision so later runs reuse it. Reaching any cache at all also needs your user in `trusted-users`, or the daemon silently ignores the substituter.

## Incidental fix

Compiling under 27.2 surfaced a pre-existing warning (present on every version, from 2025-04):

```
phpstan.el:65: the function `tramp-dissect-file-name' might not be defined at runtime
```

Both `declare-function` forms quoted the function name and arglist — which disables the declaration — and one named the file `"tamp"` instead of `"tramp"`. Fixed; the compile is now warning-free on both 27.2 and current master Emacs.

## Verification

Every commit compiles cleanly on Emacs 27.2 on its own. `eask compile` and the local Flycheck end-to-end (unmodified + editor-mode buffers) both pass on system Emacs with the MELPA Stable dependencies.
