### PR TITLE
Add an ERT test suite and run it in CI

### DIFF
--- a/.github/run-emacs-27-2.sh
+++ b/.github/run-emacs-27-2.sh
@@ -52,4 +52,7 @@ eask install-deps
 echo "==> eask compile"
 eask compile
 
+echo "==> eask test ert"
+eask test ert ./test/*-test.el
+
 echo "==> OK"

--- a/Eask
+++ b/Eask
@@ -10,7 +10,7 @@
 (package-file "phpstan.el")
 (files "*.el")
 
-(script "test" "echo \"Error: no test specified\" && exit 1")
+(script "test" "eask test ert ./test/*-test.el")
 
 (source 'gnu)
 (source 'melpa)

--- a/Eask.27
+++ b/Eask.27
@@ -21,7 +21,7 @@
 (package-file "phpstan.el")
 (files "*.el")
 
-(script "test" "echo \"Error: no test specified\" && exit 1")
+(script "test" "eask test ert ./test/*-test.el")
 
 (source 'gnu)
 (source 'melpa-stable)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ install:
 compile:
 	$(EASK) compile
 
-all: clean autoloads install compile
+test:
+	$(EASK) test ert ./test/*-test.el
+
+all: clean autoloads install compile test
 
 autoloads:
 	$(EASK) generate autoloads
@@ -18,4 +21,4 @@ autoloads:
 clean:
 	$(EASK) clean all
 
-.PHONY: all autoloads clean
+.PHONY: all autoloads clean compile install test

--- a/test/flycheck-phpstan-test.el
+++ b/test/flycheck-phpstan-test.el
@@ -1,0 +1,70 @@
+;;; flycheck-phpstan-test.el --- Tests for flycheck-phpstan.el  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Friends of Emacs-PHP development
+
+;; License: GPL-3.0-or-later
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; ERT tests for `flycheck-phpstan-parse-output', covering the output shapes a
+;; container runtime produces (JSON preceded by progress on STDERR) and the
+;; no-JSON fallback.
+
+;;; Code:
+(require 'ert)
+(require 'flycheck-phpstan)
+
+(defconst flycheck-phpstan-test--json
+  (concat "{\"totals\":{\"errors\":0,\"file_errors\":1},"
+          "\"files\":{\"/app/test.php\":{\"errors\":1,\"messages\":["
+          "{\"message\":\"Function f not found.\",\"line\":4,\"ignorable\":true}"
+          "]}},\"errors\":[]}")
+  "A minimal PHPStan JSON report with one error on line 4.")
+
+(ert-deftest flycheck-phpstan-test-parse-json ()
+  "A plain JSON report yields the error it describes."
+  (let* ((phpstan-disable-buffer-errors t)
+         (errors (flycheck-phpstan-parse-output flycheck-phpstan-test--json)))
+    (should (= 1 (length errors)))
+    (should (= 4 (flycheck-error-line (car errors))))
+    (should (string-match-p "Function f not found"
+                            (flycheck-error-message (car errors))))))
+
+(ert-deftest flycheck-phpstan-test-parse-json-with-stderr-prefix ()
+  "The report must be found even when a runtime prefixes it with progress.
+Apple container writes progress to STDERR, which the checker merges into
+STDOUT, so the JSON does not start at the beginning of the output."
+  (let* ((phpstan-disable-buffer-errors t)
+         (output (concat "[0/6] Fetching image\n"
+                         "[6/6] Starting container\n"
+                         flycheck-phpstan-test--json))
+         (errors (flycheck-phpstan-parse-output output)))
+    (should (= 1 (length errors)))
+    (should (= 4 (flycheck-error-line (car errors))))))
+
+(ert-deftest flycheck-phpstan-test-parse-non-json-is-surfaced ()
+  "When there is no JSON report, the raw output is surfaced, not discarded.
+A swallowed fallback would show a failing PHPStan as a clean buffer."
+  (let* ((phpstan-disable-buffer-errors t)
+         (output "Bootstrap file /app/tests/bootstrap.php does not exist.")
+         (errors (flycheck-phpstan-parse-output output)))
+    (should (= 1 (length errors)))
+    (should (eq 'warning (flycheck-error-level (car errors))))
+    (should (string-match-p "Bootstrap file"
+                            (flycheck-error-message (car errors))))))
+
+(provide 'flycheck-phpstan-test)
+;;; flycheck-phpstan-test.el ends here

--- a/test/phpstan-test.el
+++ b/test/phpstan-test.el
@@ -1,0 +1,188 @@
+;;; phpstan-test.el --- Tests for phpstan.el  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Friends of Emacs-PHP development
+
+;; License: GPL-3.0-or-later
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; ERT tests for the parts of phpstan.el that can be exercised without a
+;; running PHPStan.  Anything that would touch the project or the filesystem
+;; is stubbed, so the tests stay hermetic.
+
+;;; Code:
+(require 'ert)
+(require 'cl-lib)
+(require 'phpstan)
+
+;;; Utilities
+
+(ert-deftest phpstan-test-plist-to-alist ()
+  (should (equal '(("a" . 1) ("b" . 2))
+                 (phpstan--plist-to-alist '(:a 1 :b 2))))
+  (should (equal nil (phpstan--plist-to-alist nil))))
+
+;;; Container runtime detection
+
+(ert-deftest phpstan-test-container-runtime-command ()
+  "Only the symbol forms ask phpstan.el to build a `run' command line."
+  (let ((phpstan-executable 'docker))
+    (should (equal "docker" (phpstan--container-runtime-command))))
+  (let ((phpstan-executable 'container))
+    (should (equal "container" (phpstan--container-runtime-command))))
+  ;; A complete command line must not be rewritten, so this returns nil.
+  (let ((phpstan-executable '("docker" "run" "--rm" "img")))
+    (should-not (phpstan--container-runtime-command)))
+  (let ((phpstan-executable "/usr/bin/phpstan"))
+    (should-not (phpstan--container-runtime-command)))
+  (let ((phpstan-executable nil))
+    (should-not (phpstan--container-runtime-command))))
+
+(ert-deftest phpstan-test-container-executable-p ()
+  "Recognize a container even in the explicit command-line form."
+  (dolist (exe '(docker container))
+    (let ((phpstan-executable exe))
+      (should (phpstan--container-executable-p))))
+  (let ((phpstan-executable '("docker" "run" "--rm" "img")))
+    (should (phpstan--container-executable-p)))
+  (let ((phpstan-executable '("container" "run" "--rm" "img")))
+    (should (phpstan--container-executable-p)))
+  ;; An unknown runtime is not treated as a container.
+  (let ((phpstan-executable '("podman" "run" "img")))
+    (should-not (phpstan--container-executable-p)))
+  (let ((phpstan-executable "/usr/bin/phpstan"))
+    (should-not (phpstan--container-executable-p)))
+  (let ((phpstan-executable nil))
+    (should-not (phpstan--container-executable-p))))
+
+;;; Version parsing
+
+(ert-deftest phpstan-test-version-from-output ()
+  (should (equal "1.12.33"
+                 (phpstan--version-from-output
+                  "PHPStan - PHP Static Analysis Tool 1.12.33\n")))
+  ;; A container runtime prints progress before the version; the last line wins.
+  (should (equal "2.2.5"
+                 (phpstan--version-from-output
+                  "[0/6] Fetching image\n[6/6] Starting container\nPHPStan - PHP Static Analysis Tool 2.2.5\n")))
+  (should-not (phpstan--version-from-output nil))
+  (should-not (phpstan--version-from-output "")))
+
+(ert-deftest phpstan-test-editor-mode-available-p ()
+  "Version gating, exercised through the cache to avoid shelling out."
+  (let ((phpstan-activate-editor-mode nil))
+    ;; The alist is keyed by the whole command line joined with spaces.
+    (cl-flet ((available (version)
+                (let ((phpstan-executable-versions-alist (list (cons "phpstan" version))))
+                  (phpstan-editor-mode-available-p "phpstan"))))
+      (should (available "1.12.27"))
+      (should (available "1.13.0"))
+      (should (available "2.1.17"))
+      (should (available "2.2.5"))
+      (should (available "1.12.99-dev@abcdef"))
+      (should-not (available "1.12.26"))
+      (should-not (available "2.1.16"))
+      (should-not (available ""))))
+  ;; Explicit overrides ignore the version entirely.
+  (let ((phpstan-activate-editor-mode 'enabled))
+    (should (phpstan-editor-mode-available-p "anything")))
+  (let ((phpstan-activate-editor-mode 'disabled))
+    (should-not (phpstan-editor-mode-available-p "anything"))))
+
+;;; Path normalization
+
+(ert-deftest phpstan-test-normalize-path ()
+  ;; Use a real absolute root and derive the expected value with the same
+  ;; `expand-file-name' the code uses, so the test survives Windows drive
+  ;; letters and separators rather than assuming a Unix-shaped "/proj/".
+  (let ((root (file-name-as-directory
+               (expand-file-name "phpstan-test-proj" temporary-file-directory))))
+    (cl-letf (((symbol-function 'php-project-get-root-dir) (lambda () root)))
+      (let ((src (expand-file-name "src/A.php" root)))
+        ;; A containerized PHPStan sees the project under its mount point.
+        (let ((phpstan-executable 'docker)
+              (phpstan-replace-path-prefix nil))
+          (should (equal (expand-file-name "src/A.php" "/app")
+                         (phpstan-normalize-path src))))
+        ;; A local executable leaves the path alone.
+        (let ((phpstan-executable nil)
+              (phpstan-replace-path-prefix nil))
+          (should (equal src (phpstan-normalize-path src))))))))
+
+;;; Command line construction
+
+(defmacro phpstan-test--with-stubbed-project (&rest body)
+  "Run BODY with the project root and config file stubbed to fixed values.
+The root is a real absolute path under `temporary-file-directory', so paths
+survive `expand-file-name' on every platform."
+  (declare (indent 0))
+  `(let ((phpstan-test--root (file-name-as-directory
+                              (expand-file-name "phpstan-test-proj"
+                                                temporary-file-directory))))
+     (cl-letf (((symbol-function 'php-project-get-root-dir)
+                (lambda () phpstan-test--root))
+               ((symbol-function 'phpstan-get-config-file)
+                (lambda () (expand-file-name "phpstan.neon" phpstan-test--root))))
+       (let ((phpstan-replace-path-prefix nil)
+             (phpstan-autoload-file nil)
+             (phpstan-memory-limit nil)
+             (phpstan-level nil)
+             (phpstan-use-xdebug-option nil)
+             (phpstan--use-xdebug-option nil))
+         ,@body))))
+
+(ert-deftest phpstan-test-command-args-keeps-command-name ()
+  "The `(STRING . (ARGUMENTS ...))' form must run the command, not its first arg."
+  (phpstan-test--with-stubbed-project
+    (let ((phpstan-executable '("docker" "run" "--rm" "-v" "/proj:/app" "img")))
+      (let ((args (phpstan-get-command-args :include-executable t)))
+        (should (equal "docker" (car args)))
+        (should (equal '("docker" "run" "--rm" "-v" "/proj:/app" "img" "analyze")
+                       (seq-take args 7)))))))
+
+(ert-deftest phpstan-test-command-args-does-not-mutate-executable ()
+  "`phpstan-get-command-args' must not grow the caller's `phpstan-executable'."
+  (phpstan-test--with-stubbed-project
+    (let* ((original (list "docker" "run" "--rm" "img"))
+           (phpstan-executable original))
+      (phpstan-get-command-args :include-executable t)
+      (phpstan-get-command-args :include-executable t)
+      (should (equal '("docker" "run" "--rm" "img") original))
+      ;; Two calls must produce the same thing.
+      (should (equal (phpstan-get-command-args :include-executable t)
+                     (phpstan-get-command-args :include-executable t))))))
+
+(ert-deftest phpstan-test-command-args-does-not-mutate-options ()
+  "The `:options' list is the caller's; it must come back unchanged."
+  (phpstan-test--with-stubbed-project
+    (let ((phpstan-executable "/bin/phpstan")
+          (options (list "--generate-baseline")))
+      (cl-letf (((symbol-function 'phpstan-get-executable-and-args)
+                 (lambda () (list "/bin/phpstan"))))
+        (phpstan-get-command-args :include-executable t :options options)
+        (phpstan-get-command-args :include-executable t :options options)
+        (should (equal '("--generate-baseline") options))))))
+
+(ert-deftest phpstan-test-command-args-normalizes-config-for-container ()
+  "The config file is rewritten to the container mount point."
+  (phpstan-test--with-stubbed-project
+    (let ((phpstan-executable 'docker))
+      (let ((args (phpstan-get-command-args :include-executable t)))
+        (should (member (expand-file-name "phpstan.neon" "/app") args))
+        (should-not (member (phpstan-get-config-file) args))))))
+
+(provide 'phpstan-test)
+;;; phpstan-test.el ends here


### PR DESCRIPTION
Adds the package's first automated tests and runs them in CI.

## Why

There were no tests: the Eask `test` script was a placeholder that only errored, and CI ran `make all`, which compiles but executes nothing. Every bug fixed in the recent PRs (#62–#65) — a destructive `nconc` growing `phpstan-executable`, the `(STRING . (ARGS...))` form dropping the command name, the version probe reading `docker --version` instead of PHPStan, the parse fallback silently discarding failures — was invisible on inspection and only surfaced when the code ran. That is exactly what a test suite should catch.

## What

- **`test/phpstan-test.el`** — container detection (`phpstan--container-runtime-command` / `-executable-p`), version parsing (`phpstan--version-from-output`), editor-mode gating (through the version cache, so it never shells out), path normalization, and `phpstan-get-command-args`: that it keeps the command name for the `(STRING . (ARGS...))` form, does not mutate `phpstan-executable` or the caller's `:options`, and rewrites the config path to the container mount point. Project and filesystem access is stubbed with `cl-letf`, so the tests are hermetic.
- **`test/flycheck-phpstan-test.el`** — that the JSON report is found even when a container runtime prefixes it with progress on STDERR, and that a no-JSON failure is surfaced as a warning instead of dropped.

Each test was verified to **fail when its bug is reintroduced** (e.g. swapping `append` back to `nconc` fails the two mutation tests; reverting the JSON detection to `string-prefix-p` fails the stderr-prefix test), so they pin behaviour rather than merely describe it.

## Wiring

`make all` now runs `eask test ert` after compiling, so the existing CI — which already calls `make all` — runs the suite on all nine matrix jobs with no workflow change, including the Emacs 27.2 job through `Eask.27`. The local `.github/run-emacs-27-2.sh` helper runs the tests too. `Eask` gains a `test` script (`eask run script test`); `Eask.27` is kept in sync.

## Verification

13/13 pass on system Emacs and on Emacs 27.2 (via nix-emacs-ci, MELPA Stable deps). `make all` runs compile + test cleanly.
