### PR TITLE
Do not error normalizing a nil path under a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes of the `phpstan.el` are documented in this file using the [K
 * Fix editor mode detection asking the wrong program for its version.  Only the first element of the command line was probed, which is the container runtime for `(phpstan-executable . docker)` / `container` and `php` for a PHAR without the executable bit — so `docker --version` and `php --version` were parsed as PHPStan versions (`d1c06ef`, `Technologies`) and editor mode was silently disabled for every setup except a directly executable `phpstan`.
 * `phpstan-version` and `phpstan-editor-mode-available-p` now take the whole command line, as returned by `phpstan-get-executable-and-args`.  A bare string is still accepted.  `phpstan-version` no longer merges STDERR into the version string, which a container runtime pollutes with its progress report.
 * Fix `declare-function` forms for `tramp` that quoted the function name and argument list (and misspelled `tramp` as `tamp`), so the byte compiler warned that `tramp-dissect-file-name` might not be defined at runtime.
+* Fix a container run erroring when the project has no configuration file.  `phpstan-normalize-path` was handed the nil from `phpstan-get-config-file` and passed it to `replace-regexp-in-string`; it now returns nil for a nil path, so the command line simply omits `-c`.
 
 ### Removed
 

--- a/phpstan.el
+++ b/phpstan.el
@@ -393,16 +393,19 @@ such a command line still needs project paths rewritten to its mount point."
 
 If neither `phpstan-replace-path-prefix' nor a container executable is set,
 it returns the value of `SOURCE' as it is."
-  (let ((root-directory (expand-file-name (php-project-get-root-dir)))
-        (prefix
+  (let ((prefix
          (or phpstan-replace-path-prefix
              (and (phpstan--container-executable-p) "/app"))))
-    (if prefix
-        (expand-file-name
-         (replace-regexp-in-string (concat "\\`" (regexp-quote root-directory))
-                                   ""
-                                   source-original t t)
-         prefix)
+    ;; SOURCE-ORIGINAL is nil when there is no path to normalize, e.g. when
+    ;; `phpstan-get-config-file' finds no configuration.  Fall through rather
+    ;; than passing nil to `replace-regexp-in-string', which would error.
+    (if (and prefix source-original)
+        (let ((root-directory (expand-file-name (php-project-get-root-dir))))
+          (expand-file-name
+           (replace-regexp-in-string (concat "\\`" (regexp-quote root-directory))
+                                     ""
+                                     source-original t t)
+           prefix))
       (or source source-original))))
 
 (defun phpstan-get-level ()

--- a/test/phpstan-test.el
+++ b/test/phpstan-test.el
@@ -122,6 +122,20 @@
               (phpstan-replace-path-prefix nil))
           (should (equal src (phpstan-normalize-path src))))))))
 
+(ert-deftest phpstan-test-normalize-path-nil ()
+  "A nil path yields nil rather than erroring, even under a container.
+`phpstan-get-config-file' returns nil when a project has no configuration,
+and a containerized run would otherwise pass that nil to
+`replace-regexp-in-string'."
+  (cl-letf (((symbol-function 'php-project-get-root-dir) (lambda () "/proj/")))
+    (let ((phpstan-replace-path-prefix nil))
+      (dolist (exe '(docker container ("docker" "run" "img") nil "/bin/phpstan"))
+        (let ((phpstan-executable exe))
+          (should-not (phpstan-normalize-path nil))))
+      ;; The optional SOURCE fallback still applies when it is given.
+      (let ((phpstan-executable 'docker))
+        (should (equal "fallback" (phpstan-normalize-path nil "fallback")))))))
+
 ;;; Command line construction
 
 (defmacro phpstan-test--with-stubbed-project (&rest body)
@@ -183,6 +197,17 @@ survive `expand-file-name' on every platform."
       (let ((args (phpstan-get-command-args :include-executable t)))
         (should (member (expand-file-name "phpstan.neon" "/app") args))
         (should-not (member (phpstan-get-config-file) args))))))
+
+(ert-deftest phpstan-test-command-args-without-config-under-container ()
+  "A container run with no configuration file must not error.
+`phpstan-get-config-file' returns nil then, and normalizing it used to
+error; the command line should simply omit the `-c' flag."
+  (phpstan-test--with-stubbed-project
+    (cl-letf (((symbol-function 'phpstan-get-config-file) (lambda () nil)))
+      (let ((phpstan-executable 'docker))
+        (let ((args (phpstan-get-command-args :include-executable t)))
+          (should-not (member "-c" args))
+          (should (member "analyze" args)))))))
 
 (provide 'phpstan-test)
 ;;; phpstan-test.el ends here


### PR DESCRIPTION
Fixes a container run erroring when the project has no configuration file — found while writing the test suite in #66.

## The bug

`phpstan-get-command-args` opens with:

```elisp
(config (or config (phpstan-normalize-path (phpstan-get-config-file))))
```

`phpstan-get-config-file` returns nil when the project has no `phpstan.neon(.dist)` and `phpstan-config-file` is unset. For a container executable, `phpstan-normalize-path` then passed that nil to `replace-regexp-in-string`, raising `(wrong-type-argument arrayp nil)`. The local case was unaffected — it returns `(or source source-original)` without touching the path.

So `M-x phpstan-analyze-project`, `phpstan-analyze-this-file`, flycheck, and flymake all errored under `(phpstan-executable . docker)` / `container` whenever the project had no config file. That combination is real: `phpstan-enable-on-no-config-file` explicitly enables PHPStan from a Composer autoload alone.

```elisp
(cl-letf (((symbol-function 'php-project-get-root-dir) (lambda () "/proj/")))
  (let ((phpstan-executable 'docker))
    (phpstan-normalize-path nil)))
;; => (wrong-type-argument arrayp nil)   ; now => nil
```

## The fix

Guard `phpstan-normalize-path` at the source: a nil path falls through to the `(or source source-original)` branch instead of the container rewrite, returning nil (or the optional `SOURCE` fallback) rather than erroring. Fixing the one function protects every caller. With config nil, the command line now simply omits `-c`, which is correct.

## Tests

Two regression tests in `test/phpstan-test.el`, both verified to fail (with the original `wrong-type-argument`) when the fix is reverted:

- `phpstan-test-normalize-path-nil` — nil in, nil out across docker / container / explicit-command / local / executable forms, and that the optional `SOURCE` fallback still applies.
- `phpstan-test-command-args-without-config-under-container` — a docker run with `phpstan-get-config-file` stubbed to nil produces a command line with no `-c` and no error.

15/15 pass on system Emacs and Emacs 27.2; compile is warning-free on both.
