### PR TITLE
Use if-let* / when-let* instead of the obsolete plain forms

### DIFF
--- a/phpstan-hover.el
+++ b/phpstan-hover.el
@@ -243,7 +243,7 @@
   "Return hover type string at point.
 
 If PREFER-PHPDOC is non-nil, return PHPDoc type when available."
-  (when-let ((datum (phpstan-hover--datum-at-point)))
+  (when-let* ((datum (phpstan-hover--datum-at-point)))
     (let ((type (plist-get datum :typeDescr))
           (phpdoc-type (plist-get datum :phpDocType)))
       (if (and prefer-phpdoc
@@ -332,7 +332,7 @@ This honors `phpstan-hover-display-backend'."
 
 (defun phpstan-hover--show-at-point ()
   "Show hover text for current point if available."
-  (if-let ((datum (phpstan-hover--datum-at-point)))
+  (if-let* ((datum (phpstan-hover--datum-at-point)))
       (phpstan-hover--show (phpstan-hover--format-message datum))
     (setq phpstan-hover--last-shown nil)
     (phpstan-hover--hide)))

--- a/phpstan.el
+++ b/phpstan.el
@@ -480,7 +480,7 @@ it returns the value of `SOURCE' as it is."
 (defun phpstan-find-baseline-file ()
   "Find PHPStan baseline file of current project."
   (interactive)
-  (if-let ((path (locate-dominating-file default-directory phpstan-baseline-file)))
+  (if-let* ((path (locate-dominating-file default-directory phpstan-baseline-file)))
       (find-file (expand-file-name phpstan-baseline-file path))
     (user-error "Baseline file not found.  Try running M-x phpstan-generate-baseline")))
 


### PR DESCRIPTION
`if-let` and `when-let` are obsolete as of Emacs 31.1, and the byte compiler warns about all three uses (phpstan.el:483, phpstan-hover.el:246 and :335). Each binds a single value, so the starred forms are a direct, behaviour-preserving replacement. Both are available on the supported Emacs (27.1+) through subr-x — verified by loading the sources uncompiled on Emacs 27.2 and exercising the `if-let*` path.

Compilation is now warning-free on Emacs 27.2 and current master Emacs; the test suite still passes (15/15).