### PR TITLE
Map JSON false and null to nil in phpstan--parse-json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes of the `phpstan.el` are documented in this file using the [K
 * `phpstan-version` and `phpstan-editor-mode-available-p` now take the whole command line, as returned by `phpstan-get-executable-and-args`.  A bare string is still accepted.  `phpstan-version` no longer merges STDERR into the version string, which a container runtime pollutes with its progress report.
 * Fix `declare-function` forms for `tramp` that quoted the function name and argument list (and misspelled `tramp` as `tamp`), so the byte compiler warned that `tramp-dissect-file-name` might not be defined at runtime.
 * Fix a container run erroring when the project has no configuration file.  `phpstan-normalize-path` was handed the nil from `phpstan-get-config-file` and passed it to `replace-regexp-in-string`; it now returns nil for a nil path, so the command line simply omits `-c`.
+* Fix `phpstan--parse-json` reading JSON `false` (and, on `json-parse-buffer`, `null`) as a truthy symbol.  A non-ignorable message (`"ignorable":false`) was treated as ignorable by both backends, so its identifier was shown with the 🪪 prefix and `phpstan-insert-ignore` offered it — even though it cannot be ignored.  Both parser paths now map `false`/`null` to nil.
 
 ### Removed
 

--- a/phpstan.el
+++ b/phpstan.el
@@ -429,11 +429,18 @@ it returns the value of `SOURCE' as it is."
       (when (search-forward-regexp "^{" nil t)
         (backward-char 1)
         (delete-region (point-min) (point))))
+    ;; Map JSON false and null to nil.  PHPStan's `ignorable' is a boolean read
+    ;; in a truthy context, and by default both parsers return a truthy symbol
+    ;; for false (`:false' / `:json-false'); `json-parse-buffer' also returns a
+    ;; truthy `:null'.  Without this, a non-ignorable message looks ignorable,
+    ;; and the two parsers disagree on null.
     (if (eval-when-compile (and (fboundp 'json-serialize)
                                 (fboundp 'json-parse-buffer)))
         (with-no-warnings
-          (json-parse-buffer :object-type 'plist :array-type 'list))
-      (let ((json-object-type 'plist) (json-array-type 'list))
+          (json-parse-buffer :object-type 'plist :array-type 'list
+                             :false-object nil :null-object nil))
+      (let ((json-object-type 'plist) (json-array-type 'list)
+            (json-false nil) (json-null nil))
         (json-read-object)))))
 
 (defun phpstan--expand-file-name (name)

--- a/test/flycheck-phpstan-test.el
+++ b/test/flycheck-phpstan-test.el
@@ -25,6 +25,7 @@
 
 ;;; Code:
 (require 'ert)
+(require 'cl-lib)
 (require 'flycheck-phpstan)
 
 (defconst flycheck-phpstan-test--json
@@ -65,6 +66,25 @@ A swallowed fallback would show a failing PHPStan as a clean buffer."
     (should (eq 'warning (flycheck-error-level (car errors))))
     (should (string-match-p "Bootstrap file"
                             (flycheck-error-message (car errors))))))
+
+(ert-deftest flycheck-phpstan-test-identifier-only-when-ignorable ()
+  "The identifier prefix is shown only for an ignorable message.
+A non-ignorable message (\"ignorable\":false) reads its flag as nil now, so
+it must not look like something `phpstan-insert-ignore' can act on."
+  (let* ((phpstan-disable-buffer-errors t)
+         (phpstan-identifier-prefix "ID:")
+         (flycheck-phpstan-ignore-metadata-list nil)
+         (output (concat "{\"files\":{\"/x\":{\"messages\":["
+                         "{\"message\":\"parse error\",\"line\":1,\"ignorable\":false,"
+                         "\"identifier\":\"ignore.parseError\"},"
+                         "{\"message\":\"undefined\",\"line\":2,\"ignorable\":true,"
+                         "\"identifier\":\"variable.undefined\"}]}}}"))
+         (errors (flycheck-phpstan-parse-output output))
+         (by-line (lambda (n) (car (cl-remove-if-not
+                                    (lambda (e) (= n (flycheck-error-line e))) errors)))))
+    (should-not (string-match-p "ID:" (flycheck-error-message (funcall by-line 1))))
+    (should (string-match-p "ID:variable.undefined"
+                            (flycheck-error-message (funcall by-line 2))))))
 
 (provide 'flycheck-phpstan-test)
 ;;; flycheck-phpstan-test.el ends here

--- a/test/flymake-phpstan-test.el
+++ b/test/flymake-phpstan-test.el
@@ -77,6 +77,19 @@ This is what lets `phpstan-insert-ignore' work from Flymake."
       (should (equal '((4 "function.notFound") (7 "constant.notFound"))
                      phpstan--ignorable-errors)))))
 
+(ert-deftest flymake-phpstan-test-parse-skips-non-ignorable ()
+  "A non-ignorable message (\"ignorable\":false) is not offered to ignore."
+  (with-temp-buffer
+    (let ((source (current-buffer))
+          (phpstan-disable-buffer-errors nil)
+          (json (concat "{\"files\":{\"/x\":{\"messages\":["
+                        "{\"message\":\"parse error\",\"line\":1,\"ignorable\":false,"
+                        "\"identifier\":\"ignore.parseError\"},"
+                        "{\"message\":\"undefined\",\"line\":2,\"ignorable\":true,"
+                        "\"identifier\":\"variable.undefined\"}]}}}")))
+      (flymake-phpstan--parse json source)
+      (should (equal '((2 "variable.undefined")) phpstan--ignorable-errors)))))
+
 (ert-deftest flymake-phpstan-test-parse-json-with-stderr-prefix ()
   "The report is found even when a container prefixes it with progress."
   (with-temp-buffer

--- a/test/phpstan-test.el
+++ b/test/phpstan-test.el
@@ -35,6 +35,33 @@
                  (phpstan--plist-to-alist '(:a 1 :b 2))))
   (should (equal nil (phpstan--plist-to-alist nil))))
 
+;;; JSON parsing
+
+(ert-deftest phpstan-test-parse-json-false-is-nil ()
+  "JSON false and null read as nil, not a truthy symbol.
+`ignorable' is read in a truthy context, so `false' must be nil."
+  (with-temp-buffer
+    (insert "{\"a\":false,\"b\":null,\"c\":true}")
+    (let ((data (phpstan--parse-json (current-buffer))))
+      (should-not (plist-get data :a))
+      (should-not (plist-get data :b))
+      (should (eq t (plist-get data :c))))))
+
+(ert-deftest phpstan-test-update-ignorable-skips-non-ignorable ()
+  "Only ignorable messages feed `phpstan--ignorable-errors'.
+A non-ignorable message (\"ignorable\":false) must not be offered to
+`phpstan-insert-ignore'."
+  (with-temp-buffer
+    (insert (concat "{\"files\":{\"/x\":{\"messages\":["
+                    "{\"message\":\"parse error\",\"line\":1,\"ignorable\":false,"
+                    "\"identifier\":\"ignore.parseError\"},"
+                    "{\"message\":\"undefined\",\"line\":2,\"ignorable\":true,"
+                    "\"identifier\":\"variable.undefined\"}]}}}"))
+    (let ((errors (phpstan--plist-to-alist
+                   (plist-get (phpstan--parse-json (current-buffer)) :files))))
+      (phpstan-update-ignorebale-errors-from-json-buffer errors)
+      (should (equal '((2 "variable.undefined")) phpstan--ignorable-errors)))))
+
 ;;; Container runtime detection
 
 (ert-deftest phpstan-test-container-runtime-command ()


### PR DESCRIPTION
Fixes a shared JSON-parsing bug that made non-ignorable PHPStan errors look ignorable — found while adding the flymake tests in #69.

## The bug

`phpstan--parse-json` returned a *truthy* symbol for JSON `false`: `json-parse-buffer` gives `:false`, the `json-read-object` fallback gives `:json-false`. PHPStan's `ignorable` flag is read in a truthy context, so a non-ignorable message (`"ignorable":false`, e.g. a parse error) was treated as **ignorable** by every consumer:

- `flycheck-phpstan` and `flymake-phpstan` appended the identifier with the 🪪 prefix, which tells the user "you can `@phpstan-ignore` this";
- `phpstan-update-ignorebale-errors-from-json-buffer` collected it, so `phpstan-insert-ignore` offered to ignore an error PHPStan says cannot be ignored.

`json-parse-buffer` also returns a truthy `:null` for JSON `null`, while the fallback returns nil — so the two paths disagreed, and a `:null` reaching `concat` (an absent tip, say) would error on a modern Emacs.

```elisp
;; message with "ignorable":false
(plist-get msg :ignorable)   ; => :false  (truthy!)  — now => nil
```

## The fix

Pass `:false-object nil :null-object nil` to `json-parse-buffer`, and bind `json-false`/`json-null` to nil for the `json-read-object` fallback. Both paths now map `false` and `null` to nil.

I checked every consumer first: nothing uses `plist-member`, so no code distinguishes `false` from an absent key; the other JSON reads are numbers or strings guarded with `numberp` (in `phpstan-hover`), so nil is safe throughout. This also makes the two parser paths agree on `null`.

## Result

- `flycheck-phpstan`: a non-ignorable parse error no longer shows 🪪; an ignorable error still does.
- `flymake-phpstan`: same.
- `phpstan-insert-ignore` no longer offers non-ignorable identifiers.

## Tests

Four regression tests, each verified to fail when the mapping is reverted:
- `phpstan-test-parse-json-false-is-nil` — `false`/`null` read as nil, `true` as `t`.
- `phpstan-test-update-ignorable-skips-non-ignorable` — `phpstan--ignorable-errors` excludes the non-ignorable message.
- `flycheck-phpstan-test-identifier-only-when-ignorable` and `flymake-phpstan-test-parse-skips-non-ignorable` — the identifier appears only for the ignorable one.

25 tests total pass on system Emacs and Emacs 27.2; compile is warning-free on both.
