### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes of the `phpstan.el` are documented in this file using the [Keep a Changelog](https://keepachangelog.com/) principles.
 
-## Unreleased
+## [0.10.0]
 
 ### Added
 

--- a/Eask
+++ b/Eask
@@ -1,7 +1,7 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
 (package "phpstan"
-         "0.9.0"
+         "0.10.0"
          "Interface to PHPStan (PHP static analyzer)")
 
 (website-url "https://github.com/emacs-php/phpstan.el")

--- a/Eask.27
+++ b/Eask.27
@@ -12,7 +12,7 @@
 ;; rest in sync with `Eask', which is the source of truth.
 
 (package "phpstan"
-         "0.9.0"
+         "0.10.0"
          "Interface to PHPStan (PHP static analyzer)")
 
 (website-url "https://github.com/emacs-php/phpstan.el")

--- a/flycheck-phpstan.el
+++ b/flycheck-phpstan.el
@@ -4,10 +4,10 @@
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 15 Mar 2018
-;; Version: 0.9.0
+;; Version: 0.10.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
-;; Package-Requires: ((emacs "27.1") (flycheck "26") (phpstan "0.9.0"))
+;; Package-Requires: ((emacs "27.1") (flycheck "26") (phpstan "0.10.0"))
 ;; License: GPL-3.0-or-later
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/flymake-phpstan.el
+++ b/flymake-phpstan.el
@@ -4,10 +4,10 @@
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 31 Mar 2020
-;; Version: 0.9.0
+;; Version: 0.10.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
-;; Package-Requires: ((emacs "27.1") (phpstan "0.9.0"))
+;; Package-Requires: ((emacs "27.1") (phpstan "0.10.0"))
 ;; License: GPL-3.0-or-later
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/phpstan-hover.el
+++ b/phpstan-hover.el
@@ -4,9 +4,10 @@
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 16 Feb 2026
+;; Version: 0.10.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
-;; Package-Requires: ((emacs "27.1") (phpstan "0.9.0"))
+;; Package-Requires: ((emacs "27.1") (phpstan "0.10.0"))
 ;; License: GPL-3.0-or-later
 
 ;;; Commentary:

--- a/phpstan.el
+++ b/phpstan.el
@@ -4,7 +4,7 @@
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Created: 15 Mar 2018
-;; Version: 0.9.0
+;; Version: 0.10.0
 ;; Keywords: tools, php
 ;; Homepage: https://github.com/emacs-php/phpstan.el
 ;; Package-Requires: ((emacs "27.1") (compat "30") (php-mode "1.22.3") (php-runtime "0.2"))


### PR DESCRIPTION
Release PR for **0.10.0**. Merge this, then tag `0.10.0` on master.

## Version bumps

- `Version:` header → 0.10.0 in `phpstan.el`, `flycheck-phpstan.el`, `flymake-phpstan.el`, and `phpstan-hover.el`.
- `Eask` and `Eask.27` package version → 0.10.0.
- `CHANGELOG.md`: `## Unreleased` → `## [0.10.0]`.

## Two judgment calls — please confirm

1. **Sub-package dependency bumped to `(phpstan "0.10.0")`** in `flycheck-phpstan`, `flymake-phpstan`, and `phpstan-hover`. They're released in lockstep and genuinely need this phpstan release — the flycheck generic-checker rewrite and the flymake JSON parser both use phpstan.el internals introduced in this cycle — so requiring the older 0.9.0 would allow a broken mix. Tell me if you'd rather keep it at 0.9.0.

2. **`phpstan-hover.el` gained a `Version` header** (it had none). Added for consistency with the other package files. If it was omitted on purpose (experimental, not yet on MELPA), say so and I'll drop it.

## Why 0.10.0

Not a patch (0.9.1): this raises the Emacs floor to **27.1** (dropping Emacs 26), obsoletes `phpstan-flycheck-auto-set-executable`, and adds Apple container support and `phpstan-hover-mode`. In 0.x, a minor bump carries these. The obsolete declaration in `phpstan.el` already named `"0.10.0"`, so this matches.

Not 1.0.0: the internals were just reworked heavily; staying on 0.x a bit longer reads as more honest than declaring API stability now.

## What's in 0.10.0

The full list is in the changelog. Headline items:

**Added** — `phpstan-hover-mode` (experimental); Apple `container` as a `phpstan-executable`.

**Changed** — `flycheck-phpstan` is now a generic checker (no more injecting an executable via `:enabled`, no `php` required in `exec-path`); `flymake-phpstan` reads JSON, reaching parity with flycheck (identifiers, tips, and `phpstan-insert-ignore` / `phpstan-copy-dumped-type` now work from Flymake).

**Fixed** — a cascade uncovered while reworking the checker: Docker/container never actually worked through Flycheck (host paths sent to the container, JSON hidden behind STDERR progress, failures swallowed as a clean buffer); editor-mode version detection probed the wrong program; `phpstan-get-command-args` mutated its inputs and dropped the command name; JSON `false`/`null` read as truthy so non-ignorable errors looked ignorable; and more.

**Removed** — Emacs 26 and earlier.

## Verification

This release also adds the package's first test suite (25 ERT tests) and runs it in CI across Ubuntu/macOS/Windows on Emacs 27.2 through snapshot. All green on this branch; `make test` and compile are clean locally on system Emacs and Emacs 27.2.
